### PR TITLE
Confirmation modal fixes

### DIFF
--- a/pages/swap.tsx
+++ b/pages/swap.tsx
@@ -1,4 +1,4 @@
-import { styled, useTheme } from '@mui/material';
+import { styled } from '@mui/material';
 import { useSorobanReact } from '@soroban-react/core';
 import { ButtonError, ButtonLight, ButtonPrimary } from 'components/Buttons/Button';
 import { AutoColumn } from 'components/Column';
@@ -111,7 +111,6 @@ export function SwapComponent({
   onCurrencyChange?: (selected: Pick<SwapState, Field.INPUT | Field.OUTPUT>) => void;
   disableTokenInputs?: boolean;
 }) {
-  const theme = useTheme();
   const sorobanContext = useSorobanReact();
   const { address } = sorobanContext;
 
@@ -278,7 +277,7 @@ export function SwapComponent({
     // allowance.state === AllowanceState.ALLOWED ? allowance.permitSignature : undefined
   );
 
-  const handleSwap = useCallback(() => {
+  const handleSwap = () => {
     if (!swapCallback) {
       return;
     }
@@ -301,11 +300,10 @@ export function SwapComponent({
       .catch((error) => {
         setSwapState((currentState) => ({
           ...currentState,
-          swapError: error,
-          swapResult: undefined,
+          showConfirm: false,
         }));
       });
-  }, [swapCallback]);
+  };
 
   const showDetailsDropdown = Boolean(
     userHasSpecifiedInputOutput && (trade || routeIsLoading || routeIsSyncing),

--- a/src/components/Notifications/SnackbarNotification.tsx
+++ b/src/components/Notifications/SnackbarNotification.tsx
@@ -11,7 +11,9 @@ import { MinusCircle, Plus, PlusCircle } from 'react-feather';
 
 const CustomSnackbarContent = styled(SnackbarContent)`
   border-radius: 16px;
-  background: ${({ theme }) => `linear-gradient(${theme.palette.customBackground.bg1}, ${theme.palette.customBackground.bg1}) padding-box,
+  background: ${({
+    theme,
+  }) => `linear-gradient(${theme.palette.customBackground.bg1}, ${theme.palette.customBackground.bg1}) padding-box,
               linear-gradient(90deg, rgba(180,239,175,0.5) 0%, rgba(255,255,255,0) 35%, rgba(255,255,255,0) 65%, rgba(180,239,175,0.5) 100%) border-box`};
   border: 1px solid transparent;
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
@@ -20,7 +22,7 @@ const CustomSnackbarContent = styled(SnackbarContent)`
   color: ${({ theme }) => theme.palette.primary.main};
   font-weight: 500;
   font-size: 20px;
-`
+`;
 
 const MessageWrapper = styled('div')`
   display: flex;
@@ -28,18 +30,19 @@ const MessageWrapper = styled('div')`
   align-items: center;
   justify-content: center;
   gap: 16px;
-`
+`;
 
 const SubtitleText = styled('span')`
   color: ${({ theme }) => theme.palette.custom.textQuaternary};
   font-weight: 400;
   font-size: 14px;
-`
+`;
 
 export default function SnackbarNotification() {
-  const theme = useTheme()
-  const { SnackbarContext } = useContext(AppContext)
-  const { openSnackbar, setOpenSnackbar, snackbarTitle, snackbarMessage, snackbarType } = SnackbarContext
+  const theme = useTheme();
+  const { SnackbarContext } = useContext(AppContext);
+  const { openSnackbar, setOpenSnackbar, snackbarTitle, snackbarMessage, snackbarType } =
+    SnackbarContext;
 
   const handleClose = () => {
     setOpenSnackbar(false);
@@ -48,18 +51,32 @@ export default function SnackbarNotification() {
   const Icon = () => {
     switch (snackbarType) {
       case SnackbarIconType.SWAP:
-        return <Image src={theme.palette.mode === "dark" ? swapIconLight.src : swapIconDark.src} alt="swapIcon" width={32} height={32} />
+        return (
+          <Image
+            src={theme.palette.mode === 'dark' ? swapIconLight.src : swapIconDark.src}
+            alt="swapIcon"
+            width={32}
+            height={32}
+          />
+        );
       case SnackbarIconType.MINT:
-        return <Plus width={32} height={32} />
+        return <Plus width={32} height={32} />;
       case SnackbarIconType.ADD_LIQUIDITY:
-        return <PlusCircle width={32} height={32} />
+        return <PlusCircle width={32} height={32} />;
       case SnackbarIconType.REMOVE_LIQUIDITY:
-        return <MinusCircle width={32} height={32} />
-      
+        return <MinusCircle width={32} height={32} />;
+
       default:
-        return <Image src={theme.palette.mode === "dark" ? swapIconLight.src : swapIconDark.src} alt="swapIcon" width={32} height={32} />
+        return (
+          <Image
+            src={theme.palette.mode === 'dark' ? swapIconLight.src : swapIconDark.src}
+            alt="swapIcon"
+            width={32}
+            height={32}
+          />
+        );
     }
-  }
+  };
 
   const message = (
     <React.Fragment>
@@ -71,12 +88,12 @@ export default function SnackbarNotification() {
         </Column>
       </MessageWrapper>
     </React.Fragment>
-  )
+  );
 
   return (
     <Box sx={{ width: 500 }}>
       <Snackbar
-        anchorOrigin={{ vertical: 'top', horizontal: 'center'}}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
         open={openSnackbar}
         onClose={handleClose}
         autoHideDuration={5000}

--- a/src/components/Swap/ConfirmSwapModal.tsx
+++ b/src/components/Swap/ConfirmSwapModal.tsx
@@ -21,7 +21,7 @@ const StyledSwapHeader = styled(RowBetween)(({ theme }) => ({
 const HeaderButtonContainer = styled(RowFixed)`
   padding: 0 12px;
   gap: 16px;
-`
+`;
 
 export enum ConfirmModalState {
   REVIEWING,
@@ -40,39 +40,38 @@ function useConfirmModalState({
   doesTradeDiffer,
   onCurrencySelection,
 }: {
-  trade: InterfaceTrade
-  allowedSlippage: any//Percent
-  onSwap: () => void
-  allowance: any//Allowance
-  doesTradeDiffer?: boolean
-  onCurrencySelection: (field: Field, currency: TokenType) => void
+  trade: InterfaceTrade;
+  allowedSlippage: any; //Percent
+  onSwap: () => void;
+  allowance: any; //Allowance
+  doesTradeDiffer?: boolean;
+  onCurrencySelection: (field: Field, currency: TokenType) => void;
 }) {
-  const [confirmModalState, setConfirmModalState] = useState<ConfirmModalState>(ConfirmModalState.REVIEWING)
-  const [approvalError, setApprovalError] = useState<PendingModalError>()
-  const [pendingModalSteps, setPendingModalSteps] = useState<PendingConfirmModalState[]>([])
+  const [confirmModalState, setConfirmModalState] = useState<ConfirmModalState>(
+    ConfirmModalState.REVIEWING,
+  );
+  const [approvalError, setApprovalError] = useState<PendingModalError>();
+  const [pendingModalSteps, setPendingModalSteps] = useState<PendingConfirmModalState[]>([]);
 
   // This is a function instead of a memoized value because we do _not_ want it to update as the allowance changes.
   // For example, if the user needs to complete 3 steps initially, we should always show 3 step indicators
   // at the bottom of the modal, even after they complete steps 1 and 2.
   const generateRequiredSteps = useCallback(() => {
-    const steps: PendingConfirmModalState[] = []
+    const steps: PendingConfirmModalState[] = [];
     // Any existing USDT allowance needs to be reset before we can approve the new amount (mainnet only).
     // See the `approve` function here: https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7#code
-    if (
-      allowance.state === AllowanceState.REQUIRED &&
-      allowance.allowedAmount.greaterThan(0)
-    ) {
-      steps.push(ConfirmModalState.RESETTING_USDT)
+    if (allowance.state === AllowanceState.REQUIRED && allowance.allowedAmount.greaterThan(0)) {
+      steps.push(ConfirmModalState.RESETTING_USDT);
     }
     if (allowance.state === AllowanceState.REQUIRED && allowance.needsSetupApproval) {
-      steps.push(ConfirmModalState.APPROVING_TOKEN)
+      steps.push(ConfirmModalState.APPROVING_TOKEN);
     }
     if (allowance.state === AllowanceState.REQUIRED && allowance.needsPermitSignature) {
-      steps.push(ConfirmModalState.PERMITTING)
+      steps.push(ConfirmModalState.PERMITTING);
     }
-    steps.push(ConfirmModalState.PENDING_CONFIRMATION)
-    return steps
-  }, [allowance])
+    steps.push(ConfirmModalState.PENDING_CONFIRMATION);
+    return steps;
+  }, [allowance]);
 
   // const { chainId } = useWeb3React()
   // const trace = useTrace()
@@ -80,7 +79,7 @@ function useConfirmModalState({
 
   // const nativeCurrency = useNativeCurrency(chainId)
 
-  const [wrapTxHash, setWrapTxHash] = useState<string>()
+  const [wrapTxHash, setWrapTxHash] = useState<string>();
   // const { execute: onWrap } = useWrapCallback(
   //   nativeCurrency,
   //   trade.inputAmount.currency,
@@ -89,48 +88,48 @@ function useConfirmModalState({
   // const wrapConfirmed = useIsTransactionConfirmed(wrapTxHash)
   // const prevWrapConfirmed = usePrevious(wrapConfirmed)
   const catchUserReject = async (e: any, errorType: PendingModalError) => {
-    setConfirmModalState(ConfirmModalState.REVIEWING)
+    setConfirmModalState(ConfirmModalState.REVIEWING);
     // if (didUserReject(e)) return
-    console.error(e)
-    setApprovalError(errorType)
-  }
+    console.error(e);
+    setApprovalError(errorType);
+  };
 
   const performStep = useCallback(
     async (step: ConfirmModalState) => {
       switch (step) {
         case ConfirmModalState.WRAPPING:
-          setConfirmModalState(ConfirmModalState.WRAPPING)
-          break
+          setConfirmModalState(ConfirmModalState.WRAPPING);
+          break;
         case ConfirmModalState.RESETTING_USDT:
-          setConfirmModalState(ConfirmModalState.RESETTING_USDT)
-          break
+          setConfirmModalState(ConfirmModalState.RESETTING_USDT);
+          break;
         case ConfirmModalState.APPROVING_TOKEN:
-          setConfirmModalState(ConfirmModalState.APPROVING_TOKEN)
-          break
+          setConfirmModalState(ConfirmModalState.APPROVING_TOKEN);
+          break;
         case ConfirmModalState.PERMITTING:
-          setConfirmModalState(ConfirmModalState.PERMITTING)
-          break
+          setConfirmModalState(ConfirmModalState.PERMITTING);
+          break;
         case ConfirmModalState.PENDING_CONFIRMATION:
-          setConfirmModalState(ConfirmModalState.PENDING_CONFIRMATION)
+          setConfirmModalState(ConfirmModalState.PENDING_CONFIRMATION);
           try {
-            onSwap()
+            onSwap();
           } catch (e) {
-            catchUserReject(e, PendingModalError.CONFIRMATION_ERROR)
+            catchUserReject(e, PendingModalError.CONFIRMATION_ERROR);
           }
-          break
+          break;
         default:
-          setConfirmModalState(ConfirmModalState.REVIEWING)
-          break
+          setConfirmModalState(ConfirmModalState.REVIEWING);
+          break;
       }
     },
-    [onSwap]
-  )
+    [onSwap],
+  );
 
   const startSwapFlow = useCallback(() => {
-    const steps = generateRequiredSteps()
-    setPendingModalSteps(steps)
-    performStep(steps[0])
-  }, [generateRequiredSteps, performStep])
+    const steps = generateRequiredSteps();
+    setPendingModalSteps(steps);
+    performStep(steps[0]);
+  }, [generateRequiredSteps, performStep]);
 
   // const previousSetupApprovalNeeded = usePrevious(
   //   allowance.state === AllowanceState.REQUIRED ? allowance.needsSetupApproval : undefined
@@ -179,11 +178,18 @@ function useConfirmModalState({
   // }, [allowance, confirmModalState, doesTradeDiffer, performStep])
 
   const onCancel = () => {
-    setConfirmModalState(ConfirmModalState.REVIEWING)
-    setApprovalError(undefined)
-  }
+    setConfirmModalState(ConfirmModalState.REVIEWING);
+    setApprovalError(undefined);
+  };
 
-  return { startSwapFlow, onCancel, confirmModalState, approvalError, pendingModalSteps, wrapTxHash }
+  return {
+    startSwapFlow,
+    onCancel,
+    confirmModalState,
+    approvalError,
+    pendingModalSteps,
+    wrapTxHash,
+  };
 }
 
 export default function ConfirmSwapModal({
@@ -202,42 +208,54 @@ export default function ConfirmSwapModal({
   fiatValueInput,
   fiatValueOutput,
 }: {
-  trade: InterfaceTrade
-  inputCurrency?: TokenType
-  originalTrade?: InterfaceTrade
-  swapResult?: any//SwapResult
-  allowedSlippage: any//Percent
-  allowance: any//Allowance
-  onAcceptChanges: () => void
-  onConfirm: () => void
-  swapError?: Error
-  onDismiss: () => void
-  onCurrencySelection: (field: Field, currency: TokenType) => void
-  swapQuoteReceivedDate?: Date
-  fiatValueInput: { data?: number; isLoading: boolean }
-  fiatValueOutput: { data?: number; isLoading: boolean }
-  }) {
-  const { startSwapFlow, onCancel, confirmModalState, approvalError, pendingModalSteps, wrapTxHash } = 
-    useConfirmModalState({
-      trade,
-      allowedSlippage,
-      onSwap: onConfirm,
-      onCurrencySelection,
-      allowance,
-    })
-  
-  const swapFailed = Boolean(swapError) // && !didUserReject(swapError)
+  trade: InterfaceTrade;
+  inputCurrency?: TokenType;
+  originalTrade?: InterfaceTrade;
+  swapResult?: any; //SwapResult
+  allowedSlippage: any; //Percent
+  allowance: any; //Allowance
+  onAcceptChanges: () => void;
+  onConfirm: () => void;
+  swapError?: Error;
+  onDismiss: () => void;
+  onCurrencySelection: (field: Field, currency: TokenType) => void;
+  swapQuoteReceivedDate?: Date;
+  fiatValueInput: { data?: number; isLoading: boolean };
+  fiatValueOutput: { data?: number; isLoading: boolean };
+}) {
+  const {
+    startSwapFlow,
+    onCancel,
+    confirmModalState,
+    approvalError,
+    pendingModalSteps,
+    wrapTxHash,
+  } = useConfirmModalState({
+    trade,
+    allowedSlippage,
+    onSwap: onConfirm,
+    onCurrencySelection,
+    allowance,
+  });
+
+  const swapFailed = Boolean(swapError); // && !didUserReject(swapError)
 
   // const showAcceptChanges = Boolean(
   //   trade && confirmModalState !== ConfirmModalState.PENDING_CONFIRMATION
   // )
-  const showAcceptChanges = false
+  const showAcceptChanges = false;
   const modalHeader = useCallback(() => {
     if (confirmModalState !== ConfirmModalState.REVIEWING && !showAcceptChanges) {
-      return null
+      return null;
     }
-    return <SwapModalHeader inputCurrency={inputCurrency} trade={trade} allowedSlippage={allowedSlippage} />
-  }, [allowedSlippage, confirmModalState, showAcceptChanges, trade, inputCurrency])
+    return (
+      <SwapModalHeader
+        inputCurrency={inputCurrency}
+        trade={trade}
+        allowedSlippage={allowedSlippage}
+      />
+    );
+  }, [allowedSlippage, confirmModalState, showAcceptChanges, trade, inputCurrency]);
 
   const modalBottom = useCallback(() => {
     if (confirmModalState === ConfirmModalState.REVIEWING || showAcceptChanges) {
@@ -255,7 +273,7 @@ export default function ConfirmSwapModal({
           onAcceptChanges={onAcceptChanges}
           swapErrorMessage={swapFailed ? swapError?.message : undefined}
         />
-      )
+      );
     }
     return (
       <PendingModalContent
@@ -265,13 +283,40 @@ export default function ConfirmSwapModal({
         trade={trade}
         swapResult={swapResult}
         wrapTxHash={wrapTxHash}
-        tokenApprovalPending={allowance.state === AllowanceState.REQUIRED && allowance.isApprovalPending}
-        revocationPending={allowance.state === AllowanceState.REQUIRED && allowance.isRevocationPending}
+        tokenApprovalPending={
+          allowance.state === AllowanceState.REQUIRED && allowance.isApprovalPending
+        }
+        revocationPending={
+          allowance.state === AllowanceState.REQUIRED && allowance.isRevocationPending
+        }
       />
-    )
-  }, [allowance.isApprovalPending, allowance.isRevocationPending, allowance.state, allowedSlippage, confirmModalState, fiatValueInput, fiatValueOutput, onAcceptChanges, pendingModalSteps, showAcceptChanges, startSwapFlow, swapError?.message, swapFailed, swapQuoteReceivedDate, swapResult, trade, wrapTxHash])
+    );
+  }, [
+    allowance.isApprovalPending,
+    allowance.isRevocationPending,
+    allowance.state,
+    allowedSlippage,
+    confirmModalState,
+    fiatValueInput,
+    fiatValueOutput,
+    onAcceptChanges,
+    pendingModalSteps,
+    showAcceptChanges,
+    startSwapFlow,
+    swapError?.message,
+    swapFailed,
+    swapQuoteReceivedDate,
+    swapResult,
+    trade,
+    wrapTxHash,
+  ]);
 
-  const titleToShow = confirmModalState === ConfirmModalState.REVIEWING ? "Confirm Swap" : confirmModalState === ConfirmModalState.PENDING_CONFIRMATION ? "You will receive" : undefined
+  const titleToShow =
+    confirmModalState === ConfirmModalState.REVIEWING
+      ? 'Confirm Swap'
+      : confirmModalState === ConfirmModalState.PENDING_CONFIRMATION
+      ? 'You will receive'
+      : undefined;
 
   return (
     <Modal
@@ -286,7 +331,7 @@ export default function ConfirmSwapModal({
         topContent={modalHeader}
         bottomContent={modalBottom}
         // headerContent={l2Badge}
-      /> 
+      />
     </Modal>
-  )
+  );
 }

--- a/src/components/Swap/PendingModalContent/index.tsx
+++ b/src/components/Swap/PendingModalContent/index.tsx
@@ -1,54 +1,59 @@
-import { css, keyframes, styled, useTheme } from '@mui/material'
-import Column, { ColumnCenter } from 'components/Column'
-import Row from 'components/Row'
-import { LabelSmall, SubHeaderLarge } from 'components/Text'
-import { TokenType } from 'interfaces'
-import Link from 'next/link'
-import { ReactNode, useRef } from 'react'
-import { InterfaceTrade } from 'state/routing/types'
-import { ConfirmModalState } from '../ConfirmSwapModal'
+import { css, keyframes, styled, useTheme } from '@mui/material';
+import Column, { ColumnCenter } from 'components/Column';
+import Row from 'components/Row';
+import { LabelSmall, SubHeaderLarge } from 'components/Text';
+import { TokenType } from 'interfaces';
+import Link from 'next/link';
+import { ReactNode, useRef } from 'react';
+import { InterfaceTrade } from 'state/routing/types';
+import { ConfirmModalState } from '../ConfirmSwapModal';
 import {
   AnimatedEntranceConfirmationIcon,
   AnimationType,
   CurrencyLoader,
   LoadingIndicatorOverlay,
   LogoContainer,
-} from './Logos'
-import { TradeSummary } from './TradeSummary'
+} from './Logos';
+import { TradeSummary } from './TradeSummary';
 
 export const PendingModalContainer = styled(ColumnCenter)`
   margin: 48px 0 8px;
-`
+`;
 
 const HeaderContainer = styled(ColumnCenter)<{ $disabled?: boolean }>`
   ${({ $disabled }) => $disabled && `opacity: 0.5;`}
   gap: 10px;
   overflow: visible;
-`
+`;
 
 const StepCircle = styled('div')<{ active: boolean }>`
   height: 10px;
   width: 10px;
   border-radius: 50%;
-  background-color: ${({ theme, active }) => (active ? theme.palette.customBackground.accentAction : theme.palette.custom.textTertiary)};
-  outline: 3px solid ${({ theme, active }) => (active ? theme.palette.customBackground.accentActionSoft : theme.palette.custom.accentTextLightTertiary)};
+  background-color: ${({ theme, active }) =>
+    active ? theme.palette.customBackground.accentAction : theme.palette.custom.textTertiary};
+  outline: 3px solid
+    ${({ theme, active }) =>
+      active
+        ? theme.palette.customBackground.accentActionSoft
+        : theme.palette.custom.accentTextLightTertiary};
   transition: background-color 250ms ease-in-out;
-`
+`;
 
 const slideIn = keyframes`
   from { opacity: 0; transform: translateX(40px) }
   to { opacity: 1; transform: translateX(0px) }
-`
+`;
 const slideInAnimation = css`
   animation: from { opacity: 0; transform: translateX(40px) } to { opacity: 1; transform: translateX(0px) } 250ms ease-in-out;
-`
+`;
 const slideOut = keyframes`
   from { opacity: 1; transform: translateX(0px) }
   to { opacity: 0; transform: translateX(-40px) }
-`
+`;
 const slideOutAnimation = css`
   animation: from { opacity: 1; transform: translateX(0px) } to { opacity: 0; transform: translateX(-40px) } 250ms ease-in-out;
-`
+`;
 
 const AnimationWrapper = styled('div')`
   position: relative;
@@ -56,14 +61,14 @@ const AnimationWrapper = styled('div')`
   min-height: 72px;
   display: flex;
   flex-grow: 1;
-`
+`;
 
 export const CustomLink = styled(Link)`
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;
-`
+`;
 
 const StepTitleAnimationContainer = styled(Column)<{ disableEntranceAnimation?: boolean }>`
   position: relative;
@@ -79,7 +84,7 @@ const StepTitleAnimationContainer = styled(Column)<{ disableEntranceAnimation?: 
   &.${AnimationType.EXITING} {
     ${slideOutAnimation}
   }
-`
+`;
 
 // This component is used for all steps after ConfirmModalState.REVIEWING
 export type PendingConfirmModalState = Extract<
@@ -89,40 +94,39 @@ export type PendingConfirmModalState = Extract<
   | ConfirmModalState.PENDING_CONFIRMATION
   | ConfirmModalState.WRAPPING
   | ConfirmModalState.RESETTING_USDT
->
+>;
 
 interface PendingModalStep {
-  title: ReactNode
-  subtitle?: ReactNode
-  label?: ReactNode
-  logo?: ReactNode
-  button?: ReactNode
+  title: ReactNode;
+  subtitle?: ReactNode;
+  label?: ReactNode;
+  logo?: ReactNode;
+  button?: ReactNode;
 }
 
 interface PendingModalContentProps {
-  steps?: PendingConfirmModalState[]
-  currentStep?: any // The type of currentStep is inferred based on the values passed to it when the function is called.
-  trade?: InterfaceTrade
-  swapResult?: any//SwapResult
-  wrapTxHash?: string
-  hideStepIndicators?: boolean
-  tokenApprovalPending?: boolean
-  revocationPending?: boolean
+  steps?: PendingConfirmModalState[];
+  currentStep?: any; // The type of currentStep is inferred based on the values passed to it when the function is called.
+  trade?: InterfaceTrade;
+  swapResult?: any; //SwapResult
+  wrapTxHash?: string;
+  hideStepIndicators?: boolean;
+  tokenApprovalPending?: boolean;
+  revocationPending?: boolean;
 }
 
-
 interface ContentArgs {
-  step: PendingConfirmModalState
-  approvalCurrency?: TokenType
-  trade?: InterfaceTrade
-  swapConfirmed: boolean
-  swapPending: boolean
-  wrapPending: boolean
-  tokenApprovalPending: boolean
-  revocationPending: boolean
-  swapResult?: any//SwapResult
-  chainId?: number
-  order?: any//UniswapXOrderDetails
+  step: PendingConfirmModalState;
+  approvalCurrency?: TokenType;
+  trade?: InterfaceTrade;
+  swapConfirmed: boolean;
+  swapPending: boolean;
+  wrapPending: boolean;
+  tokenApprovalPending: boolean;
+  revocationPending: boolean;
+  swapResult?: any; //SwapResult
+  chainId?: number;
+  order?: any; //UniswapXOrderDetails
 }
 
 function getContent(args: ContentArgs): PendingModalStep {
@@ -136,8 +140,8 @@ function getContent(args: ContentArgs): PendingModalStep {
     revocationPending,
     trade,
     swapResult,
-  } = args
-  
+  } = args;
+
   switch (step) {
     case ConfirmModalState.WRAPPING:
       return {
@@ -148,13 +152,13 @@ function getContent(args: ContentArgs): PendingModalStep {
           </CustomLink>
         ),
         label: wrapPending ? `Pending...` : `Proceed in your wallet`,
-      }
+      };
     case ConfirmModalState.RESETTING_USDT:
       return {
         title: `Reset USDT`,
         subtitle: `USDT requires resetting approval when spending limits are too low.`,
         label: revocationPending ? `Pending...` : `Proceed in your wallet`,
-      }
+      };
     case ConfirmModalState.APPROVING_TOKEN:
       return {
         title: `Enable spending ${approvalCurrency?.symbol ?? 'this token'} on Uniswap`,
@@ -164,39 +168,46 @@ function getContent(args: ContentArgs): PendingModalStep {
           </CustomLink>
         ),
         label: tokenApprovalPending ? `Pending...` : `Proceed in your wallet`,
-      }
+      };
     case ConfirmModalState.PERMITTING:
       return {
         title: `Allow ${approvalCurrency?.symbol ?? 'this token'} to be used for swapping`,
         subtitle: (
-          <CustomLink href="https://support.uniswap.org/hc/en-us/articles/8120520483085" target='_blank'>
+          <CustomLink
+            href="https://support.uniswap.org/hc/en-us/articles/8120520483085"
+            target="_blank"
+          >
             Why is this required?
           </CustomLink>
         ),
         label: `Proceed in your wallet`,
-      }
+      };
     case ConfirmModalState.PENDING_CONFIRMATION: {
-      let labelText: string | null = null
-      let href: string | null = null
+      let labelText: string | null = null;
+      let href: string | null = null;
 
       if (swapConfirmed && swapResult) {
-        labelText = `View on Explorer`
-        href = "https://google.com"//TODO: getExplorerLink(chainId, swapResult.response.hash, ExplorerDataType.TRANSACTION)
+        labelText = `View on Explorer`;
+        href = 'https://google.com'; //TODO: getExplorerLink(chainId, swapResult.response.hash, ExplorerDataType.TRANSACTION)
       } else if (swapPending) {
-        labelText = `Proceed in your wallet`
+        labelText = `Proceed in your wallet`;
       }
-      
+
       return {
-        title: swapPending ? `Swap submitted` : swapConfirmed ? `Success` : `Waiting for confirmation`,
+        title: swapPending
+          ? `Waiting for confirmation`
+          : swapConfirmed
+          ? `Success`
+          : `Waiting for confirmation`,
         subtitle: trade ? <TradeSummary trade={trade} /> : null,
         label: href ? (
-          <CustomLink href={href} target='_blank'>
+          <CustomLink href={href} target="_blank">
             {labelText}
           </CustomLink>
         ) : (
           labelText
         ),
-      }
+      };
     }
   }
 }
@@ -219,14 +230,14 @@ export function PendingModalContent({
   // const wrapConfirmed = useIsTransactionConfirmed(wrapTxHash)
   // const uniswapXSwapConfirmed = Boolean(swapResult)
 
-  const swapConfirmed = swapResult ? true : false
+  const swapConfirmed = swapResult ? true : false;
 
-  const swapPending = !swapResult ? true : false
-  const wrapPending = false//wrapTxHash != undefined && !wrapConfirmed
+  const swapPending = !swapResult ? true : false;
+  const wrapPending = false; //wrapTxHash != undefined && !wrapConfirmed
 
   const { label, button } = getContent({
     step: currentStep,
-    approvalCurrency : trade?.inputAmount?.currency,
+    approvalCurrency: trade?.inputAmount?.currency,
     swapConfirmed,
     swapPending,
     wrapPending,
@@ -234,12 +245,12 @@ export function PendingModalContent({
     revocationPending,
     swapResult,
     trade,
-  })
-  const theme = useTheme()
+  });
+  const theme = useTheme();
 
   // const order = useOrder(swapResult?.type === TradeFillType.UniswapX ? swapResult.response.orderHash : '')
 
-  const currentStepContainerRef = useRef<HTMLDivElement>(null)
+  const currentStepContainerRef = useRef<HTMLDivElement>(null);
   // useUnmountingAnimation(currentStepContainerRef, () => AnimationType.EXITING)
 
   // if (steps.length === 0) {
@@ -252,7 +263,7 @@ export function PendingModalContent({
   // }
 
   // // On mainnet, we show the success icon once the tx is sent, since it takes longer to confirm than on L2s.
-  const showSuccess = swapConfirmed || (!swapPending)
+  const showSuccess = swapConfirmed || !swapPending;
 
   return (
     <PendingModalContainer gap="24px">
@@ -264,66 +275,71 @@ export function PendingModalContent({
             asBadge={currentStep === ConfirmModalState.APPROVING_TOKEN}
           />
         )}
-        {currentStep === ConfirmModalState.PENDING_CONFIRMATION && showSuccess && <AnimatedEntranceConfirmationIcon />}
+        {currentStep === ConfirmModalState.PENDING_CONFIRMATION && showSuccess && (
+          <AnimatedEntranceConfirmationIcon />
+        )}
         {((currentStep === ConfirmModalState.PENDING_CONFIRMATION && !showSuccess) ||
           tokenApprovalPending ||
           wrapPending ||
           revocationPending) && <LoadingIndicatorOverlay />}
       </LogoContainer>
       <HeaderContainer
-        $disabled={revocationPending || tokenApprovalPending || wrapPending || (!swapPending && !showSuccess)}
+        $disabled={
+          revocationPending || tokenApprovalPending || wrapPending || (!swapPending && !showSuccess)
+        }
       >
-        {trade && trade.inputAmount && 
-        
-        <AnimationWrapper>
-        {steps?.map((step) => {
-          const { title, subtitle } = getContent({
-            step,
-            approvalCurrency: trade?.inputAmount?.currency,
-            swapConfirmed,
-            swapPending,
-            wrapPending,
-            revocationPending,
-            tokenApprovalPending,
-            swapResult,
-            trade,
-          });
-          // We only render one step at a time, but looping through the array allows us to keep
-          // the exiting step in the DOM during its animation.
-          return (
-            Boolean(step === currentStep) && (
-              <StepTitleAnimationContainer
-                disableEntranceAnimation={steps[0] === currentStep}
-                gap="12px"
-                key={step}
-                ref={step === currentStep ? currentStepContainerRef : undefined}
-              >
-                <SubHeaderLarge textAlign="center" data-testid="pending-modal-content-title">
-                  {title}
-                </SubHeaderLarge>
-                <LabelSmall textAlign="center">{subtitle}</LabelSmall>
-              </StepTitleAnimationContainer>
-            )
-          );
-        })}
-      </AnimationWrapper>
-      }
-      <div style={{
-        fontSize: 14,
-        fontFamily: "Inter",
-        color: theme.palette.custom.accentTextLightSecondary
-      }}>
-        {label}
-      </div>
+        {trade && trade.inputAmount && (
+          <AnimationWrapper>
+            {steps?.map((step) => {
+              const { title, subtitle } = getContent({
+                step,
+                approvalCurrency: trade?.inputAmount?.currency,
+                swapConfirmed,
+                swapPending,
+                wrapPending,
+                revocationPending,
+                tokenApprovalPending,
+                swapResult,
+                trade,
+              });
+              // We only render one step at a time, but looping through the array allows us to keep
+              // the exiting step in the DOM during its animation.
+              return (
+                Boolean(step === currentStep) && (
+                  <StepTitleAnimationContainer
+                    disableEntranceAnimation={steps[0] === currentStep}
+                    gap="12px"
+                    key={step}
+                    ref={step === currentStep ? currentStepContainerRef : undefined}
+                  >
+                    <SubHeaderLarge textAlign="center" data-testid="pending-modal-content-title">
+                      {title}
+                    </SubHeaderLarge>
+                    <LabelSmall textAlign="center">{subtitle}</LabelSmall>
+                  </StepTitleAnimationContainer>
+                )
+              );
+            })}
+          </AnimationWrapper>
+        )}
+        <div
+          style={{
+            fontSize: 14,
+            fontFamily: 'Inter',
+            color: theme.palette.custom.accentTextLightSecondary,
+          }}
+        >
+          {label}
+        </div>
       </HeaderContainer>
       {button && <Row justify="center">{button}</Row>}
       {!hideStepIndicators && !showSuccess && (
         <Row gap="14px" justify="center">
           {steps?.map((_, i) => {
-            return <StepCircle key={i} active={steps.indexOf(currentStep) === i} />
+            return <StepCircle key={i} active={steps.indexOf(currentStep) === i} />;
           })}
         </Row>
       )}
     </PendingModalContainer>
-  )
+  );
 }

--- a/src/hooks/useSwapCallback.tsx
+++ b/src/hooks/useSwapCallback.tsx
@@ -23,7 +23,7 @@ export function useSwapCallback(
   const { activeChain, address } = sorobanContext;
   const routerCallback = useRouterCallback();
 
-  return useCallback(async () => {
+  const doSwap = () => {
     console.log('Trying out the TRADE');
     if (!trade) throw new Error('missing trade');
     if (!address || !activeChain) throw new Error('wallet must be connected to swap');
@@ -83,7 +83,7 @@ export function useSwapCallback(
       bigNumberToU64(BigNumber(getCurrentTimePlusOneHour())),
     ];
 
-    routerCallback(routerMethod, args, true)
+    return routerCallback(routerMethod, args, true)
       .then((result) => {
         console.log('🚀 « result:', result);
 
@@ -98,7 +98,9 @@ export function useSwapCallback(
       })
       .catch((error) => {
         console.log('🚀 « error:', error);
-        return error;
+        throw error;
       });
-  }, [SnackbarContext, activeChain, address, routerCallback, trade]);
+  };
+
+  return doSwap;
 }


### PR DESCRIPTION
This PR solves issue #148 

-Close modal when user reject transaction
-Change "swap submitted" for "waiting for confirmation"
-Shows a check when transaction is success