### PR TITLE
fix swap button when wallet is disconnected

### DIFF
--- a/src/components/Swap/SwapComponent.tsx
+++ b/src/components/Swap/SwapComponent.tsx
@@ -21,6 +21,7 @@ import SwapCurrencyInputPanel from '../CurrencyInputPanel/SwapCurrencyInputPanel
 import SwapHeader from './SwapHeader';
 import { ArrowWrapper, SwapWrapper } from './styleds';
 import { useToken } from 'hooks/tokens/useToken';
+import { useSorobanReact } from '@soroban-react/core';
 
 const SwapSection = styled('div')(({ theme }) => ({
   position: 'relative',
@@ -96,6 +97,7 @@ export function SwapComponent({
   prefilledState?: Partial<SwapState>;
   disableTokenInputs?: boolean;
 }) {
+  const sorobanContext = useSorobanReact();
   const [showPriceImpactModal, setShowPriceImpactModal] = useState<boolean>(false);
   const [txError, setTxError] = useState<boolean>(false);
 
@@ -343,7 +345,11 @@ export function SwapComponent({
                 independentField === Field.OUTPUT ? <span>From (at most)</span> : <span>From</span>
               }
               // disabled={disableTokenInputs}
-              value={getSwapValues().insufficientLiquidity ? '0' : formattedAmounts[Field.INPUT]}
+              value={
+                sorobanContext?.address && getSwapValues().insufficientLiquidity
+                  ? '0'
+                  : formattedAmounts[Field.INPUT]
+              }
               showMaxButton={showMaxButton}
               onUserInput={handleTypeInput}
               onMax={(maxBalance) => handleTypeInput(maxBalance.toString())}
@@ -355,11 +361,7 @@ export function SwapComponent({
               loading={independentField === Field.OUTPUT && routeIsSyncing}
               currency={currencies[Field.INPUT] ?? null}
               id={'swap-input'}
-              disableInput={
-                getSwapValues().noLiquidity ||
-                getSwapValues().insufficientLiquidity ||
-                getSwapValues().noCurrencySelected
-              }
+              disableInput={getSwapValues().noLiquidity || getSwapValues().noCurrencySelected}
             />
           </SwapSection>
           <ArrowWrapper clickable={true}>

--- a/src/hooks/useSwapMainButton.ts
+++ b/src/hooks/useSwapMainButton.ts
@@ -53,9 +53,9 @@ const useSwapMainButton = ({
 
     const insufficientBalanceToken =
       Number(inputA) > Number(balanceA)
-        ? currencyA.symbol
+        ? currencyA?.symbol
         : Number(inputB) > Number(balanceB)
-        ? currencyB.symbol
+        ? currencyB?.symbol
         : '';
 
     const invalidAmount = Number(inputA) < 0 || Number(inputB) < 0;
@@ -99,7 +99,6 @@ const useSwapMainButton = ({
       noLiquidity,
       insufficientBalanceToken,
     } = getSwapValues();
-    if (routeNotFound) return 'Route not found';
     if (!address) return 'Connect Wallet';
     if (noCurrencySelected) return 'Select a token';
     if (insufficientLiquidity || noLiquidity) return 'Insufficient liquidity';
@@ -107,6 +106,7 @@ const useSwapMainButton = ({
     if (noAmountTyped) return 'Enter an amount';
     if (insufficientBalance) return 'Insufficient ' + insufficientBalanceToken + ' balance';
     if (invalidAmount) return 'Invalid amount';
+    if (routeNotFound) return 'Route not found';
 
     return 'Swap';
   };


### PR DESCRIPTION
Now always show 'connect wallet', user can type in both inputs when wallet is disconnected and the app doesn't break when pair doesn't exist and then trying to connect