### PR TITLE
fix added token selection on CurrencyList

### DIFF
--- a/src/components/SearchModal/CurrencyList/index.tsx
+++ b/src/components/SearchModal/CurrencyList/index.tsx
@@ -202,8 +202,8 @@ export default function CurrencyList({
 
       const currency = row;
 
-      const isSelected = Boolean(currency && selectedCurrency && selectedCurrency == currency);
-      const otherSelected = Boolean(currency && otherCurrency && otherCurrency == currency);
+      const isSelected = Boolean(currency && selectedCurrency && selectedCurrency.address == currency.address);
+      const otherSelected = Boolean(currency && otherCurrency && otherCurrency.address == currency.address);
       const handleSelect = (hasWarning: boolean) =>
         currency && onCurrencySelect(currency, hasWarning);
 


### PR DESCRIPTION
Fixed selection issue for newly added tokens.
Added tokens are now visibly selected on the dropdown in the swap tab.