### PR TITLE
🩹Fix visual bug on AddLiquidity modal & currency search modal.

### DIFF
--- a/src/components/Liquidity/Add/AddModalFooter.tsx
+++ b/src/components/Liquidity/Add/AddModalFooter.tsx
@@ -102,7 +102,7 @@ export default function AddModalFooter({
         <BodySmall component="div">
           <Row align="flex-start" justify="space-between" gap="sm">
             <Label>
-              {currencyA?.issuer ? currencyA?.code : currencyA?.name}{' '}
+              {currencyA && currencyA?.name?.length > 60? currencyA?.code : currencyA?.name}{' '}
               to deposit
             </Label>
             <DetailRowValue style={{ display: 'flex', alignItems: 'center' }}>
@@ -114,7 +114,7 @@ export default function AddModalFooter({
         <BodySmall component="div">
           <Row align="flex-start" justify="space-between" gap="sm">
             <Label>
-              {currencyB?.issuer ? currencyB?.code : currencyB?.name}{' '}
+              {currencyB && currencyB?.name?.length > 60? currencyB?.code : currencyB?.name}{' '}
               to deposit
             </Label>
             <DetailRowValue style={{ display: 'flex', alignItems: 'center' }}>


### PR DESCRIPTION
This pull request adds handling for displaying Stellar Classic Asset names. It displays them as CODE:${shortenIssuer(issuer)} on both the asset search modal and the add liquidity modal to fix issue #308 

![image](https://github.com/soroswap/frontend/assets/86752543/b7b3e98a-7d98-4f11-a6a9-384392ce6367)

![image](https://github.com/soroswap/frontend/assets/86752543/bf0b47be-6354-4b14-a29b-ae1771bf8d2e)

