### PR TITLE
Allow using config ⚙️ even if the wallet is not connected

### DIFF
--- a/src/components/Settings/MenuButton/index.tsx
+++ b/src/components/Settings/MenuButton/index.tsx
@@ -60,17 +60,14 @@ const ButtonContent = () => {
 }
 
 export default function MenuButton({
-  disabled,
   onClick,
   isActive,
 }: {
-  disabled: boolean
   onClick: () => void
   isActive: boolean
 }) {
   return (
     <Button
-      disabled={disabled}
       onClick={onClick}
       isActive={isActive}
       id="open-settings-dialog-button"

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,6 +1,5 @@
 // import { Percent } from '@uniswap/sdk-core'
 import { styled } from "@mui/material"
-import { useSorobanReact } from '@soroban-react/core'
 import AnimatedDropdown from 'components/AnimatedDropdown'
 import { AutoColumn } from 'components/Column'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
@@ -55,8 +54,6 @@ export default function SettingsTab({
   autoSlippage: number
   chainId?: number
 }) {
-  const { address } = useSorobanReact()
-
   const node = useRef<HTMLDivElement | null>(null)
   const [isOpen, setIsOpen] = useState(false)
   const toggleMenu = () => {
@@ -67,7 +64,7 @@ export default function SettingsTab({
 
   return (
     <Menu ref={node}>
-      <MenuButton disabled={!address} isActive={isOpen} onClick={toggleMenu} />
+      <MenuButton isActive={isOpen} onClick={toggleMenu} />
       {isOpen && (
         <MenuFlyout>
           <AnimatedDropdown open={true}>


### PR DESCRIPTION
Solves https://github.com/soroswap/frontend/issues/335

Allow users to click ⚙️ for slippage even if not logged in.

