### PR TITLE
Fix bugs with slippage settings and improve user experience

### DIFF
--- a/src/components/Settings/MaxSlippageSettings/index.tsx
+++ b/src/components/Settings/MaxSlippageSettings/index.tsx
@@ -1,11 +1,11 @@
 import Expand from 'components/Expand';
 import QuestionHelper from 'components/QuestionHelper';
 import Row, { RowBetween } from 'components/Row';
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { styled, Typography, useTheme } from '@mui/material';
 import { Alert } from '@mui/material';
 import { Input, InputContainer } from '../Input';
-import { useUserSlippageTolerance } from 'state/user/hooks';
+import { useUserSlippageTolerance, SlippageTolerance } from 'state/user/hooks';
 
 enum SlippageError {
   InvalidInput = 'InvalidInput',
@@ -42,6 +42,7 @@ export const DEFAULT_SLIPPAGE_INPUT_VALUE = 0.5;
 export default function MaxSlippageSettings({ autoSlippage }: { autoSlippage: number }) {
   const theme = useTheme();
   const [userSlippageTolerance, setUserSlippageTolerance] = useUserSlippageTolerance();
+  const isAuto = userSlippageTolerance === SlippageTolerance.Auto
 
   // If user has previously entered a custom slippage, we want to show that value in the input field
   // instead of a placeholder.
@@ -49,7 +50,7 @@ export default function MaxSlippageSettings({ autoSlippage }: { autoSlippage: nu
   const [slippageError, setSlippageError] = useState<SlippageError | false>(false);
 
   // If user has previously entered a custom slippage, we want to show the settings expanded by default.
-  const [isOpen, setIsOpen] = useState(DEFAULT_SLIPPAGE_INPUT_VALUE !== userSlippageTolerance);
+  const [isOpen, setIsOpen] = useState(!isAuto);
 
   const parseSlippageInput = (value: string) => {
     // Do not allow non-numerical characters in the input field or more than two decimals
@@ -91,6 +92,30 @@ export default function MaxSlippageSettings({ autoSlippage }: { autoSlippage: nu
       ? userSlippageTolerance > MAXIMUM_RECOMMENDED_SLIPPAGE
       : false;
 
+  const slippageInputRef = useRef()
+
+  function selectSlippageInput() {
+    if (slippageInputRef.current) {
+      slippageInputRef.current.focus()
+      slippageInputRef.current.select()
+    }
+  }
+
+  function setCustomSlippage() {
+    // When switching to custom slippage, use `auto` value as a default.
+    setUserSlippageTolerance(autoSlippage);
+    selectSlippageInput()
+  }
+
+  const removeTrailingZeroes = num =>
+    num.toFixed(2).toString().replace(/0{1,}$/, "")
+
+  useEffect(function() {
+    if (!isAuto) {
+      selectSlippageInput()
+    }
+  }, [])
+
   return (
     <Expand
       testId="max-slippage-settings"
@@ -111,10 +136,10 @@ export default function MaxSlippageSettings({ autoSlippage }: { autoSlippage: nu
       }
       button={
         <Typography color={theme.palette.primary.main}>
-          {userSlippageTolerance === DEFAULT_SLIPPAGE_INPUT_VALUE ? (
+          {isAuto ? (
             <>Auto</>
           ) : (
-            `${typeof userSlippageTolerance === 'number' ? userSlippageTolerance.toFixed(2) : 0.5}%`
+            `${removeTrailingZeroes(userSlippageTolerance)}%`
           )}
         </Typography>
       }
@@ -125,20 +150,17 @@ export default function MaxSlippageSettings({ autoSlippage }: { autoSlippage: nu
             onClick={() => {
               // Reset the input field when switching to auto
               setSlippageInput(DEFAULT_SLIPPAGE_INPUT_VALUE);
-              setUserSlippageTolerance(DEFAULT_SLIPPAGE_INPUT_VALUE);
+              setUserSlippageTolerance(SlippageTolerance.Auto);
             }}
-            isActive={userSlippageTolerance === DEFAULT_SLIPPAGE_INPUT_VALUE}
+            isActive={isAuto}
           >
             <Typography color={theme.palette.primary.main} component="div">
               Auto
             </Typography>
           </Option>
           <Option
-            onClick={() => {
-              // When switching to custom slippage, use `auto` value as a default.
-              setUserSlippageTolerance(autoSlippage);
-            }}
-            isActive={userSlippageTolerance !== DEFAULT_SLIPPAGE_INPUT_VALUE}
+            onClick={setCustomSlippage}
+            isActive={!isAuto}
           >
             <Typography color={theme.palette.primary.main} component="div">
               Custom
@@ -147,15 +169,19 @@ export default function MaxSlippageSettings({ autoSlippage }: { autoSlippage: nu
         </Switch>
         <InputContainer gap="md" error={!!slippageError}>
           <Input
+            ref={slippageInputRef}
             data-testid="slippage-input"
-            placeholder={autoSlippage.toFixed(2)}
-            value={slippageInput}
+            placeholder={autoSlippage}
+            value={isAuto ? '' : slippageInput}
             onChange={(e) => parseSlippageInput(e.target.value)}
             onBlur={() => {
               // When the input field is blurred, reset the input field to the default value
               setSlippageInput(DEFAULT_SLIPPAGE_INPUT_VALUE);
               setSlippageError(false);
             }}
+            onFocus={setCustomSlippage}
+            type="number"
+            step="0.1"
           />
           <Typography color={theme.palette.primary.main}>%</Typography>
         </InputContainer>


### PR DESCRIPTION
After talking with @esteblock I saw he wants to emulate more closely the slippage config on Uniswap. This change accomplishes that and goes a little further making it easier for the user.

FYI: It depends on my previous PR which I accidentally left in the `main` branch.

## Before

Previously when it opened the first time it was expanded and the wrong text.

![first-open-before](https://github.com/soroswap/frontend/assets/165131835/e7f973d1-4fdf-4d96-829d-5b046a5d1de8)

Compare with Uniswap


https://github.com/soroswap/frontend/assets/165131835/e4c928e0-8d1b-4f0b-9b39-8f194bcaee13

## After


https://github.com/soroswap/frontend/assets/165131835/ec22d858-9937-400f-98d8-cf1f67e00980

---

Specific details

+ By default when it opens it's in the auto state not showing the textbox yet
+ Fix toggling auto or custom
+ Make clicking and typing the slippage toggle to custom
+ Allow up down arrows with 0.1 increment and decrement
+ When opening the dialog and custom slippage focus and select allowing the user to quickly change it again.
+ Fix number formatting & connect better with state module