### PR TITLE
Fix decimals and insufficiente balance on swap

### DIFF
--- a/src/components/CurrencyInputPanel/CurrencyBalance.tsx
+++ b/src/components/CurrencyInputPanel/CurrencyBalance.tsx
@@ -76,11 +76,15 @@ export default function CurrencyBalance({
     availableBalance = Number(balance);
   }
 
+  availableBalance = Number(availableBalance?.toFixed(currency?.decimals ?? 7));
+
   const theme = useTheme();
 
   return (
     <TextWithLoadingPlaceholder
-      syncing={(isXLM && Boolean(isLoadingNetworkFees)) || isLoadingMyBalances || !tokenBalancesResponse}
+      syncing={
+        (isXLM && Boolean(isLoadingNetworkFees)) || isLoadingMyBalances || !tokenBalancesResponse
+      }
       width={150}
     >
       <RowFixed style={{ height: '17px' }}>

--- a/src/components/Swap/SwapComponent.tsx
+++ b/src/components/Swap/SwapComponent.tsx
@@ -203,15 +203,31 @@ export function SwapComponent({
 
   const handleTypeInput = useCallback(
     (value: string) => {
+      const currency = currencies[Field.INPUT];
+      const decimals = currency?.decimals ?? 7;
+
+      // Prevents user from inputting more decimals than the token supports
+      if (value.split('.').length > 1 && value.split('.')[1].length > decimals) {
+        return;
+      }
+
       onUserInput(Field.INPUT, value);
     },
-    [onUserInput],
+    [onUserInput, currencies],
   );
   const handleTypeOutput = useCallback(
     (value: string) => {
+      const currency = currencies[Field.OUTPUT];
+      const decimals = currency?.decimals ?? 7;
+
+      // Prevents user from inputting more decimals than the token supports
+      if (value.split('.').length > 1 && value.split('.')[1].length > decimals) {
+        return;
+      }
+
       onUserInput(Field.OUTPUT, value);
     },
-    [onUserInput],
+    [onUserInput, currencies],
   );
 
   const formattedAmounts = useMemo(
@@ -310,16 +326,6 @@ export function SwapComponent({
   const priceImpactSeverity = 2; //IF is < 2 it shows Swap anyway button in red
   const showPriceImpactWarning = false;
 
-  const { getMainButtonText, isMainButtonDisabled, handleMainButtonClick, getSwapValues } =
-    useSwapMainButton({
-      currencies,
-      currencyBalances,
-      formattedAmounts,
-      routeNotFound,
-      onSubmit: handleContinueToReview,
-      trade,
-    });
-
   const nativeBalance = useGetNativeTokenBalance();
 
   useEffect(() => {
@@ -357,6 +363,18 @@ export function SwapComponent({
   }, [sorobanContext, swapCallback, trade, nativeBalance.data?.validAccount]);
 
   const { networkFees, isLoading: isLoadingNetworkFees } = useSwapNetworkFees(trade, currencies);
+
+  const { getMainButtonText, isMainButtonDisabled, handleMainButtonClick, getSwapValues } =
+    useSwapMainButton({
+      currencies,
+      currencyBalances,
+      formattedAmounts,
+      routeNotFound,
+      onSubmit: handleContinueToReview,
+      trade,
+      subentryCount,
+      networkFees,
+    });
 
   const useConfirmModal = useConfirmModalState({
     trade: trade!,

--- a/src/hooks/useSwapMainButton.ts
+++ b/src/hooks/useSwapMainButton.ts
@@ -97,8 +97,8 @@ const useSwapMainButton = ({
       insufficientLiquidity,
       insufficientBalanceToken,
     } = getSwapValues();
-    if (noCurrencySelected) return 'Select a token';
     if (!address) return 'Connect Wallet';
+    if (noCurrencySelected) return 'Select a token';
     if (noAmountTyped) return 'Enter an amount';
     if (insufficientLiquidity) return 'Insufficient liquidity';
     if (data && !data?.validAccount) return 'Fund wallet to sign Transaction';

--- a/src/hooks/useSwapMainButton.ts
+++ b/src/hooks/useSwapMainButton.ts
@@ -7,6 +7,7 @@ import { Field } from 'state/swap/actions';
 import { relevantTokensType } from './useBalances';
 import useGetMyBalances from './useGetMyBalances';
 import useGetNativeTokenBalance from './useGetNativeTokenBalance';
+import { xlmTokenList } from 'constants/xlmToken';
 
 interface Props {
   currencies: any;
@@ -17,6 +18,8 @@ interface Props {
   routeNotFound: boolean;
   onSubmit: () => void;
   trade: InterfaceTrade | undefined;
+  subentryCount: number;
+  networkFees: number;
 }
 
 const useSwapMainButton = ({
@@ -26,6 +29,8 @@ const useSwapMainButton = ({
   routeNotFound,
   onSubmit,
   trade,
+  networkFees,
+  subentryCount,
 }: Props) => {
   const sorobanContext = useSorobanReact();
   const { ConnectWalletModal } = useContext(AppContext);
@@ -39,9 +44,17 @@ const useSwapMainButton = ({
     const currencyA: TokenType = currencies[Field.INPUT];
     const currencyB: TokenType = currencies[Field.OUTPUT];
 
-    const balanceA = userBalances.tokenBalancesResponse?.balances.find(
+    const isXLMCurrencyA = currencyA?.code === 'XLM';
+
+    let balanceA = userBalances.tokenBalancesResponse?.balances.find(
       (token) => token.contract == currencyA?.contract,
     )?.balance;
+
+    if (isXLMCurrencyA) {
+      balanceA = Number(balanceA) - Number(networkFees) - 1 - 0.5 * Number(subentryCount);
+      balanceA = balanceA > 0 ? balanceA : 0;
+    }
+
     const balanceB = userBalances.tokenBalancesResponse?.balances.find(
       (token) => token.contract == currencyB?.contract,
     )?.balance;


### PR DESCRIPTION
This PR solves #388  and #389 

User can not input more than the token decimals (or default 7)

Insufficient balance on XLM now is compared with the available balance instead of the full xlm balance

https://github.com/soroswap/frontend/assets/56497105/c502291f-9bbc-4a82-a57b-af657a1ca063

