### PR TITLE
Improve liquidity section

### DIFF
--- a/pages/liquidity/index.tsx
+++ b/pages/liquidity/index.tsx
@@ -101,21 +101,21 @@ export default function LiquidityPage() {
 
   return (
     <>
-      <SEO title="Liquidity - Soroswap" description="Soroswap Liquidity Pool" />
+      <SEO title="Pools - Soroswap" description="Soroswap Liquidity Pool" />
       <PageWrapper>
         <div style={{ width: '100%' }}>
           <AutoRow style={{ justifyContent: 'space-between' }}>
-            <SubHeader>Your liquidity</SubHeader>
+            <SubHeader>Your pools</SubHeader>
             <SettingsTab autoSlippage={DEFAULT_SLIPPAGE_INPUT_VALUE} />
           </AutoRow>
           <div>
-            <BodySmall>List of your liquidity positions</BodySmall>
+            <BodySmall>List of your pools positions</BodySmall>
           </div>
         </div>
         {!address ? (
           <LPTokensContainer>
             <BodySmall color={theme.palette.custom.accentTextLightSecondary} textAlign="center">
-              <>Connect to a wallet to view your liquidity.</>
+              <>Connect to a wallet to view your pools.</>
             </BodySmall>
           </LPTokensContainer>
         ) : v2IsLoading ? (
@@ -149,13 +149,13 @@ export default function LiquidityPage() {
         ) : (
           <LPTokensContainer>
             <BodySmall color={theme.palette.custom.accentTextLightSecondary} textAlign="center">
-              <>No liquidity found.</>
+              <>No pools found.</>
             </BodySmall>
           </LPTokensContainer>
         )}
         {address ? (
           <ButtonPrimary onClick={() => router.push('/liquidity/add')}>
-            + Add Liquidity
+            + Add pool
           </ButtonPrimary>
         ) : (
           <WalletButton />


### PR DESCRIPTION
In https://app.soroswap.finance/liquidity

#564 

- [ ]  Change name "Liquidity" for "Pools"
- [ ]  Show a list of all pools, similar to http://localhost:3100/?network=mainnet.
- [ ]  In list of pools, if wallet is not connected show, TVL, APY and "Connect Wallet" in the same row
- [ ]  When wallet is connected, show Share of Pool, TVL, APY and "Add Liqudiity" button.
- [ ]  Sort pools for share of pool"
- [ ]  If Share of pool is greater than 0, button should be called "Manage"
- [ ]  If shar of pool is 0, button should be called "Add Liquidity"
- [ ]  We should have a button to add liquidity to a non existing pool (Create Liqudiity Pool)

I was unable to view the list of pools in the liquidity section or create a new one, despite testing both the standalone network with the core repository running locally and the testnet. Taking a look on xBull, I noticed that it is possible to create a pool directly through the wallet. I can attempt to replicate this and observe the expected behavior.

I have some questions:

- What’s the best way to fetch and display the APY and TVL?
- What exactly is this screen: http://localhost:3100/?network=mainnet?
- Which buttons should go in this section?
 ![image](https://github.com/user-attachments/assets/70131305-5be9-4e5b-90f9-fcc1f7d8f4e3)
