### PR TITLE
Fix token metadata refetch on tab switch

### DIFF
--- a/src/hooks/tokens/useToken.ts
+++ b/src/hooks/tokens/useToken.ts
@@ -69,7 +69,7 @@ export function useToken(tokenAddress: string | undefined) {
   const { activeNetwork: network } = sorobanContext;
   const { tokensAsMap } = useAllTokens();
 
-  const { data: name } = useSWR(
+  const { data: name } = useSWRImmutable(
     tokenAddress && sorobanContext ? ['tokenName', tokenAddress, sorobanContext] : null,
     ([key, tokenAddress, sorobanContext]) => getTokenName(tokenAddress!, sorobanContext),
   );


### PR DESCRIPTION
Data is fetched through SWR, according to the docs found that useSWR default behavior is to revalidate data on certain actions like focus events, in case of token metadata we don't need that, using useSWRImmutable fixes the issue
Here is documentation for SWR https://swr.vercel.app/docs/revalidation