### PR TITLE
fix(security): correctly enforce CORS protection across API routes

### DIFF
--- a/cypress/e2e/api.test.ts
+++ b/cypress/e2e/api.test.ts
@@ -1,0 +1,46 @@
+const endpoints = ['/api/swap', '/api/swap/split', '/api/pairs'];
+
+describe('API origin protection', () => {
+  const sendRequestWithOrigin = (endpoint: string, origin: string, shouldBeBlocked: boolean) => {
+    return cy.request({
+      method: 'POST',
+      url: endpoint,
+      headers: { Origin: origin },
+      failOnStatusCode: false,
+    }).then((res) => {
+      if (shouldBeBlocked) {
+        expect(res.status).to.eq(403);
+      } else {
+        expect(res.status).to.not.eq(403);
+      }
+    });
+  };
+
+  const validOrigins = [
+    'https://app.soroswap.finance',
+    'https://paltalabs.vercel.app',
+    'http://localhost:3000',
+  ];
+
+  const invalidOrigins = [
+    'https://evil.com',
+    'https://app.soroswap.finance.evil.com',
+  ];
+
+  for (const endpoint of endpoints) {
+    it(`should allow valid origins for ${endpoint}`, () => {
+      for (const origin of validOrigins) {
+        cy.log(`Testing origin: ${origin}`);
+        sendRequestWithOrigin(endpoint, origin, false);
+      }
+    });
+
+    it(`should block invalid origins for ${endpoint}`, () => {
+      for (const origin of invalidOrigins) {
+        cy.log(`Testing origin: ${origin}`);
+        sendRequestWithOrigin(endpoint, origin, true);
+      }
+    });
+  }
+});
+

--- a/pages/api/pairs.ts
+++ b/pages/api/pairs.ts
@@ -1,14 +1,11 @@
 // pages/api/pairs.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { cors } from 'services/cors';
 import axios from 'axios';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const allowedOrigin = ['.soroswap.finance', 'http://localhost:3000', 'paltalabs.vercel.app'];
-  const origin = req.headers.origin || req.headers.referer || '';
+export default cors(handler);
 
-  if (!allowedOrigin.some((allowed) => origin.includes(allowed))) {
-    return res.status(403).json({ message: 'Forbidden' });
-  }
+async function handler(req: NextApiRequest, res: NextApiResponse) {
 
   const { network, protocol } = req.query;
 

--- a/pages/api/swap/index.ts
+++ b/pages/api/swap/index.ts
@@ -1,14 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { cors } from 'services/cors';
 import axios from 'axios';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const allowedOrigin = ['.soroswap.finance', 'http://localhost:3000', 'paltalabs.vercel.app'];
-  const origin = req.headers.origin || req.headers.referer || '';
+export default cors(handler);
 
-  if (!allowedOrigin.some((allowed) => origin.includes(allowed))) {
-    return res.status(403).json({ message: 'Forbidden' });
-  }
-
+async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { network } = req.query;
 
   if (req.method !== 'POST') {

--- a/pages/api/swap/split.ts
+++ b/pages/api/swap/split.ts
@@ -1,14 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { cors } from 'services/cors';
 import axios from 'axios';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const allowedOrigin = ['.soroswap.finance', 'http://localhost:3000', 'paltalabs.vercel.app'];
-  const origin = req.headers.origin || req.headers.referer || '';
+export default cors(handler);
 
-  if (!allowedOrigin.some((allowed) => origin.includes(allowed))) {
-    return res.status(403).json({ message: 'Forbidden' });
-  }
-
+async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { network } = req.query;
 
   if (req.method !== 'POST') {

--- a/src/services/cors.ts
+++ b/src/services/cors.ts
@@ -1,0 +1,22 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+const allowedOrigins = ['.soroswap.finance', 'localhost', 'paltalabs.vercel.app'];
+
+export function cors(
+    handler: (req: NextApiRequest, res: NextApiResponse) => Promise<void> | void
+) {
+    return async (req: NextApiRequest, res: NextApiResponse) => {
+        const origin = req.headers.origin || req.headers.referer || '';
+        let hostname = '';
+        try {
+            const url = new URL(origin);
+            hostname = url.hostname;
+        } catch (e) {
+            return res.status(403).json({ message: 'Forbidden' });
+        }
+        if (!allowedOrigins.some((allowed) => hostname.endsWith(allowed))) {
+            return res.status(403).json({ message: 'Forbidden' });
+        }
+        return handler(req, res);
+    };
+}


### PR DESCRIPTION
This pull request fixes an incorrect CORS implementation that allowed malicious origins to bypass access restrictions by using subdomains such as `https://app.soroswap.finance.evil.com`.

## Changes:
- Implemented a shared `cors()` middleware in `src/services/cors.ts`
- Applied the middleware to all API handlers
- Updated Cypress tests to verify both allowed and blocked origins across endpoints

## Why:
- The previous implementation did not properly validate the origin's hostname, which meant attackers could craft subdomains to impersonate trusted domains. This PR ensures only fully trusted origins are allowed.
